### PR TITLE
Fixed typo in the C# code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public static class MauiProgram
 
         appBuilder
             .UseMauiApp<App>()
-            .ConfigureGraphicsControls());
+            .ConfigureGraphicsControls();
 
         return appBuilder.Build();
     }


### PR DESCRIPTION
```csharp
        ...  
        appBuilder
            .UseMauiApp<App>()
            .ConfigureGraphicsControls()); //Here removed the extra ')'
        ...
    }
}
```