### PR TITLE
Fixed deployment error in Windows (SplashScreen)

### DIFF
--- a/src/GraphicsControls.Sample/Platforms/Windows/Package.appxmanifest
+++ b/src/GraphicsControls.Sample/Platforms/Windows/Package.appxmanifest
@@ -46,7 +46,6 @@
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
<img width="1891" alt="issue00" src="https://user-images.githubusercontent.com/20904914/170510722-9bb9a0be-a318-4a40-b645-7c5c4a0354bd.png">

This PR fixes a Windows deployment error that prevents the sample app from running. In the Package.appxmanifest there is a reference to an image for the SplashScreen, this in UWP made sense but if I'm not mistaken in WinUI 3 there is no native splash screen so it makes sense to remove it, right?