### PR TITLE
Fixed overlapping of ripple effect.

### DIFF
--- a/src/GraphicsControls/Handlers/Button/MaterialButtonDrawable.cs
+++ b/src/GraphicsControls/Handlers/Button/MaterialButtonDrawable.cs
@@ -69,7 +69,10 @@ namespace Microsoft.Maui.Graphics.Controls
             {
                 canvas.SaveState();
 
-                canvas.ClipRectangle(dirtyRect);
+                var border = new PathF();
+                border.AppendRoundedRectangle(dirtyRect, MaterialDefaultCornerRadius);
+
+                canvas.ClipPath(border);
 
                 canvas.FillColor = Material.Color.White.ToColor().WithAlpha(0.75f);
 

--- a/src/GraphicsControls/Handlers/Stepper/MaterialStepperDrawable.cs
+++ b/src/GraphicsControls/Handlers/Stepper/MaterialStepperDrawable.cs
@@ -144,7 +144,10 @@ namespace Microsoft.Maui.Graphics.Controls
             {
                 canvas.SaveState();
 
-                canvas.ClipRectangle(rect);
+                var border = new PathF();
+                border.AppendRoundedRectangle(rect, MaterialDefaultCornerRadius);
+
+                canvas.ClipPath(border);
 
                 canvas.FillColor = Material.Color.White.ToColor().WithAlpha(0.75f);
 

--- a/src/GraphicsControls/Handlers/Stepper/MaterialStepperDrawable.cs
+++ b/src/GraphicsControls/Handlers/Stepper/MaterialStepperDrawable.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Graphics.Controls
                 canvas.SaveState();
 
                 var border = new PathF();
-                border.AppendRoundedRectangle(rect, MaterialDefaultCornerRadius);
+                border.AppendRoundedRectangle(rect, MaterialButtonCornerRadius);
 
                 canvas.ClipPath(border);
 


### PR DESCRIPTION
Fixed overlapping of ripple effect on material stepper and material button.
If we set radius of those two elements to something bigger than their original radius and then we
set background to something darker we can see that ripple effect continues outside of the borders. This
should fix the issue since it creates a rounded variant of these elements and clips them from canvas.

[Bug showcase](https://imgur.com/a/NLado68) On top you can see original version. Under is fixed version.