### PR TITLE
Fix SpecialFolder.Personal usages

### DIFF
--- a/eng/provisioning/xcode.csx
+++ b/eng/provisioning/xcode.csx
@@ -36,7 +36,7 @@ item.XcodeSelect ();
 
 LogInstalledXcodes();
 
-var appleSdkOverride = Path.Combine(Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Preferences", "Xamarin", "Settings.plist");
+var appleSdkOverride = Path.Combine(Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Preferences", "Xamarin", "Settings.plist");
 Item("Override Apple SDK Settings")
     .Condition(item => !File.Exists(appleSdkOverride) || GetSettingValue(appleSdkOverride, "AppleSdkRoot") != GetSelectedXcodePath())
     .Action (item => {


### PR DESCRIPTION
SpecialFolder Personal is the same value as MyDocuments, both of which will be changed on Unix from `~` to `~/Documents` in .NET 8. See https://github.com/dotnet/runtime/pull/68610.

Fixing the usage of SpecialFolder.Personal here to be UserProfile, since that's really what it wants.